### PR TITLE
Fix Emoji Parsing Issue in Commits

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -14,7 +14,7 @@ module.exports = {
         confirmCommit: "Are you sure you want to proceed with the commit above?"
     },
     types: [
-        { value: "✨ feat", name: "A new feature" },
+        { value: "[EMOJI_PLACEHOLDER] feat", name: "A new feature" },
         { value: "🐛 fix", name: "A bug fix" },
         { value: "🚑 hotfix", name: "A temporary hotfix" },
         { value: "🔨 chore", name: "Other changes that don't modify src or test files" },
@@ -76,3 +76,13 @@ module.exports = {
     defaultSubject: "",
     subjectLimit: 100,
 }
+{
+
+// ... (existing configurations)
+
+usePreparedCommit: false,
+preCommitHook: (commit) => {
+  commit.subject = commit.subject.replace("[EMOJI_PLACEHOLDER]", "✨");
+},
+
+// ... (rest of the configurations)


### PR DESCRIPTION
Changes Made:

Modified the .cz-config.js file to use a placeholder for emojis in commit types.
Implemented a pre-commit hook to replace the placeholder with the actual emoji during commits.
